### PR TITLE
Updated Lambda packages to latest minor versions

### DIFF
--- a/sample/functions/Lambda/Lambda.csproj
+++ b/sample/functions/Lambda/Lambda.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/functions/TemplatedLambda/TemplatedLambda.csproj
+++ b/sample/functions/TemplatedLambda/TemplatedLambda.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/EMG.Lambda.LocalRunner/EMG.Lambda.LocalRunner.csproj
+++ b/src/EMG.Lambda.LocalRunner/EMG.Lambda.LocalRunner.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates the Amazon.Lambda.Core, Serialization.Json and TestUtilities to the latest minor release to avoid getting warnings about version mismatches using recent versions of the dotnet cli lambda templates