### PR TITLE
Add support for custom lambda contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ If omitted, the default `Amazon.Lambda.Serialization.Json.JsonSerializer` will b
 LambdaRunner.Create().UseSerializer(() => new MyCustomSerializer()) ...
 ```
 
+### Customizing the LambdaContext parameter
+If your function depends on a certain behavior of the object passed for the ILambdaContext parameter, you can specify a context factory while building the runner
+by using the `UseLambdaContext<T>(Funct<T> factory)` method. If omitted the default `TestLambdaContext` will be used.
+
 ## Notes on C# 7.1
 C# 7.1 introduced the support to [async/await directly in the Main method of a console application](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-1#async-main).
 

--- a/src/EMG.Lambda.LocalRunner/IRunnerBuilder.cs
+++ b/src/EMG.Lambda.LocalRunner/IRunnerBuilder.cs
@@ -13,6 +13,9 @@ namespace EMG.Lambda.LocalRunner
         IRunnerBuilder UseSerializer<TSerializer>(Func<TSerializer> serializerFactory)
             where TSerializer : ILambdaSerializer;
 
+        IRunnerBuilder UseLambdaContext<TLambdaContext>(Func<TLambdaContext> lambdaContextFactory)
+            where TLambdaContext : ILambdaContext;
+
         IReceivingRunnerBuilder<TInput> Receives<TInput>();
     }
 

--- a/src/EMG.Lambda.LocalRunner/Internal/InnerReceivingRunnerBuilder.cs
+++ b/src/EMG.Lambda.LocalRunner/Internal/InnerReceivingRunnerBuilder.cs
@@ -14,14 +14,15 @@ namespace EMG.Lambda.LocalRunner.Internal
         public int Port { get; set; }
 
         public Func<ILambdaSerializer> SerializerFactory { get; set; }
-
+        public Func<ILambdaContext> LambdaContextFactory { get; set; }
 
         public IReturningRunnerBuilder<TInput, TOutput> Returns<TOutput>()
         {
             return new InnerReturningRunnerBuilder<TInput, TOutput>
             {
                 Port = Port,
-                SerializerFactory = SerializerFactory
+                SerializerFactory = SerializerFactory,
+                LambdaContextFactory = LambdaContextFactory
             };
         }
 
@@ -40,7 +41,7 @@ namespace EMG.Lambda.LocalRunner.Internal
 
                 var serializer = context.RequestServices.GetRequiredService<ILambdaSerializer>();
 
-                var lambdaContext = new TestLambdaContext();
+                var lambdaContext = LambdaContextFactory();
 
                 var input = serializer.Deserialize<TInput>(context.Request.Body);
 
@@ -69,7 +70,7 @@ namespace EMG.Lambda.LocalRunner.Internal
 
                 var serializer = context.RequestServices.GetRequiredService<ILambdaSerializer>();
 
-                var lambdaContext = new TestLambdaContext();
+                var lambdaContext = LambdaContextFactory();
 
                 var input = serializer.Deserialize<TInput>(context.Request.Body);
 

--- a/src/EMG.Lambda.LocalRunner/Internal/InnerReturningRunnerBuilder.cs
+++ b/src/EMG.Lambda.LocalRunner/Internal/InnerReturningRunnerBuilder.cs
@@ -14,7 +14,7 @@ namespace EMG.Lambda.LocalRunner.Internal
         public int Port { get; set; }
 
         public Func<ILambdaSerializer> SerializerFactory { get; set; }
-
+        public Func<ILambdaContext> LambdaContextFactory { get; set; }
 
         public IFunctionRunnerBuilder<TFunction> UsesAsyncFunction<TFunction>(Func<TFunction, TInput, ILambdaContext, Task<TOutput>> executor)
             where TFunction : class, new()
@@ -31,7 +31,7 @@ namespace EMG.Lambda.LocalRunner.Internal
 
                 var serializer = context.RequestServices.GetRequiredService<ILambdaSerializer>();
 
-                var lambdaContext = new TestLambdaContext();
+                var lambdaContext = LambdaContextFactory();
 
                 var input = serializer.Deserialize<TInput>(context.Request.Body);
 
@@ -62,7 +62,7 @@ namespace EMG.Lambda.LocalRunner.Internal
 
                 var serializer = context.RequestServices.GetRequiredService<ILambdaSerializer>();
 
-                var lambdaContext = new TestLambdaContext();
+                var lambdaContext = LambdaContextFactory();
 
                 var input = serializer.Deserialize<TInput>(context.Request.Body);
 

--- a/src/EMG.Lambda.LocalRunner/Internal/InnerRunnerBuilder.cs
+++ b/src/EMG.Lambda.LocalRunner/Internal/InnerRunnerBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.Serialization.Json;
+using Amazon.Lambda.TestUtilities;
 
 namespace EMG.Lambda.LocalRunner.Internal
 {
@@ -9,7 +10,7 @@ namespace EMG.Lambda.LocalRunner.Internal
         public int Port { get; set; } = 5000;
 
         public Func<ILambdaSerializer> SerializerFactory { get; set; } = () => new JsonSerializer();
-
+        public Func<ILambdaContext> LambdaContextFactory { get; set; } = () => new TestLambdaContext();
 
         public IRunnerBuilder UsePort(int port)
         {
@@ -29,8 +30,15 @@ namespace EMG.Lambda.LocalRunner.Internal
             return new InnerReceivingRunnerBuilder<TInput>
             {
                 Port = Port,
-                SerializerFactory = SerializerFactory
+                SerializerFactory = SerializerFactory,
+                LambdaContextFactory = LambdaContextFactory
             };
+        }
+
+        public IRunnerBuilder UseLambdaContext<TLambdaContext>(Func<TLambdaContext> lambdaContextFactory) where TLambdaContext : ILambdaContext
+        {
+            LambdaContextFactory = () => lambdaContextFactory();
+            return this;
         }
     }
 }

--- a/tests/Tests.Lambda.LocalRunner/Internal/RunnerBuilderTests.cs
+++ b/tests/Tests.Lambda.LocalRunner/Internal/RunnerBuilderTests.cs
@@ -13,16 +13,18 @@ namespace Tests.Internal
     public class RunnerBuilderTests
     {
         [Test, AutoMoqData]
-        public void Receives_T_returns_initialized_builder_step(InnerRunnerBuilder sut, int port, Func<ILambdaSerializer> serializerFactory)
+        public void Receives_T_returns_initialized_builder_step(InnerRunnerBuilder sut, int port, Func<ILambdaSerializer> serializerFactory, Func<ILambdaContext> contextFactory)
         {
             sut.UsePort(port);
             sut.UseSerializer(serializerFactory);
+            sut.UseLambdaContext(contextFactory);
 
             var result = sut.Receives<string>() as InnerReceivingRunnerBuilder<string>;
             
             Assert.That(result, Is.Not.Null);
             Assert.That(result.Port, Is.EqualTo(sut.Port));
             Assert.That(result.SerializerFactory, Is.EqualTo(sut.SerializerFactory));
+            Assert.That(result.LambdaContextFactory, Is.EqualTo(sut.LambdaContextFactory));
         }
 
         [Test, AutoMoqData]


### PR DESCRIPTION
Adds a method to the runner builder to support custom ILambdaContext implementations other than TestLambdaContext.

If the method is never called, a default factory that produces a TestLambdaContext is installed, so backwards compatibility won't be broken.